### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -33,7 +33,7 @@ class syntax_plugin_pubchem extends DokuWiki_Syntax_Plugin {
   }
 
   // Handling lexer
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
     $match = substr($match,10,-2);
     return array($state,explode(':',$match));
   }
@@ -41,7 +41,7 @@ class syntax_plugin_pubchem extends DokuWiki_Syntax_Plugin {
 /**
   * Render PubChem image and link
   */
-  function render($mode, &$renderer, $data){
+  function render($mode, Doku_Renderer $renderer, $data){
     if ($mode!='xhtml') return false;
     global $pubchem_cache;
     if(!is_array($pubchem_cache)) $pubchem_cache=array();


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
